### PR TITLE
Added a version of Adrian's COVID health record use case

### DIFF
--- a/use_cases.md
+++ b/use_cases.md
@@ -147,6 +147,65 @@ three components need to be considered:
 * Trusted computing - computational resources which have access to private keys
   and plain text private data
 
+# # 2.2 Electronics Medical Records 
+
+by Adrian Gropper, edited by Juan Caballero
+
+## 2.2.1 Summary
+
+[Note: This is extracted from a longer, more detailed use case including helpful flow diagrams and an enrollment section which is stored here: https://github.com/agropper/secure-data-store/blob/master/COVID-19_Health_Report_Use_Case.md ]
+
+Alice’s health report is a short narrative impression of as little as one session of care signed by Dr. Bob to be presented to her employer and/or filed in her electronic health record for access by other care providers. Alice's records are held in trust by a community server operated through her local public library. She uses an agent to access it and grant read and/or write access to others; this agent does not need to use SSI, but it MUST be an interoperable one she can change for another at any time. For the sake of simplicity, we could use UMA as the agent and OAuth as the interoperability standard for this component [1]
+
+This use case's main virtues for the purposes of the SDS specification is that it has complex authorization requirements and data privacy requirements, some of which are best met by having a separation of concerns between authorization and storage which would ensure maximum prevention of vendor lock-in by ensuring authorization and storage are separately interchangeable/competitive.
+
+## 2.2.2 Assumptions
+
+* Each jurisdiction is different, but Alice is American and Dr. Bob practices so-called "direct medicine," meaning he needs direct access to a medical record under Alice's control rather than relying on a hospital-based or insurer-based medical record. 
+
+* A trusted community institution, like a church or community center or, in this case, a public library, can operate a privacy-by-default server for people like Alice to manage their own health records. See the link above for a more detailed use-case about the enrollment/establishment of this small-scale trust framework. See also the MyData Operator paper linked in this use case's references section [2].
+
+* Alice trusts the Library to recommend a compatible agent and/or secure data store. Bob trusts the Library to recommend a mobile wallet for signing health records as verified credentials.
+* Dr. Bob’s credentials, e.g. a medical license number, are public information that should be broadly accessible.
+* Public health authorities publish guidelines for a health report that Dr. Bob can follow and Alice’s employer accepts as a verifier.
+
+### 2.2.3 Enrollments (Library, Bob, and Alice)
+
+Note: These steps are clarified greatly with an adoption-oriented flowchart included in the longer version of this use case [3].
+
+Library: The Library installs Issuer/Verifier software and displays a list of compatible mobile wallets and secure data stores. Secure data stores that enable **independent choice** of control agent and vice versa are called out as preferable by the library. For more detail and a flow diagram, see the more detailed use-case linked from the summary section above.
+
+Dr. Bob installs a mobile identity wallet and is thus able to sign documents, post timestamps to a public blockchain or other timestamping service, and satisfy legal retention of documents and signature proofs by sending them to his secure email address. The Library’s issuer software enables Dr. Bob to self-assert his medical license and use a public notary to countersign the credential. The notary’s record can be verified online. Dr. Bob adds his notarized credential to his mobile wallet. 
+
+Alice: Alice uses her mobile phone number to sign up for a secure data store chosen from the Library’s list. If she doesn’t have one already, Alice receives, via SMS, a link to her authorization agent as suggested by the secure data store and picks a password.
+
+### 2.2.4 Alice seeks Dr. Bob's care 
+
+Alice contacts Dr. Bob (out of band), gets various tests and diagnoses (out of band) and asks Dr. Bob to issue her a health report via the Library Issuer service for self-sovereign storage and presentation. Dr. Bob accesses an Issuer service using his credentials, dictates the health report, adds Alice’s SMS number and signs the report, leaving a timestamp and a proof. Document and proof are sent to Dr. Bob’s secure email for legal retention. Alice gets an SMS or secure email from the Library with a link to the report and proof. Alice clicks the link which opens as a form on the Library site. Alice enters her authorization server endpoint onto the form. The Library server contacts Alice’s authorization server. Alice may have to sign-in. The health report and proof are sent to Alice’s secure data store. The Library deletes the documents that Dr. Bob had stored temporarily for Alice. Alice receives an SMS confirmation with a QR code that links to the document in the secure data store.
+
+### 2.2.5 Alice presents her health record to an employer
+
+Alice goes to her employer and displays the QR code in the SMS message. The employer’s browser takes them to the Library's verifier website. A capability or authorization issued by Alice MAY be involved in securing the report while it’s being copied from her data store to the verifier. The Library uses the capability/token/etc at Alice’s authorization server to get the document and proof from the secure data store. The library verifies the document for the employer. 
+[Optional:] The library deletes the document from local storage, if applicable. If the credential is intended to be presented only once, it may be revoked by the library.
+
+### 2.2.6 Alice migrates SDS without changing authorization server
+
+Alice decides to keep her authorization server but use a different secure data store. Alice opens a new secure data store account and specifies her existing authorization server as her agent. Alice moves her document from the old store to the new one. If the employer wants to check Alice’s health report again after the change, the old QR code points to the same authorization server and a file that has moved to the new document store. Where it is impossible to persist old links and references, Alice should at least be notified and have the option to manually or systematically issue a new QR code.
+
+### 2.2.7 Alice migrates SDS without changing authorization server
+
+Alice decides to keep her new data store but change the authorization server. Alice opens a new authorization server account. Alice goes to the new data store via its current authorization server and specifies her new authorization server. The employer wants to check Alice’s health report again. The old QR code points to the old authorization server. Alice has to create a new QR code that points to the new authorization server. This may need to be a manual operation, but either way is beyond the scope of this specification.
+
+### 2.2.8 Follow-up Visit
+
+A year later, Dr. Bob wants to see the old report before dictating a new report. Dr. Bob enters Alice’s SMS into a form at the Library. The Library sends Alice a message asking for her current authorization server and a request for the old report. Alice agrees and replies with links to her current authorization server and to the specific document in question. Dr. Bob, using the Library as a verifier, presents his credentials to Alice’s authorization server and retrieves the document.
+
+### 2.2.9 References
+
+[1] https://oauth.xyz/
+[2] http://mydata.org/operators/
+[3] https://github.com/agropper/secure-data-store/raw/master/diagrams/Health_Report_Use_Case.png
+
 # ​3.​ Technical Requirements derived from previous sections
 
 The following sections elaborate on the requirements that have been gathered


### PR DESCRIPTION
Longer version here: https://github.com/agropper/secure-data-store/raw/master/diagrams/Health_Report_Use_Case.png 
Feedback welcome-- not really sure which details to add or subtract for the purposes of making the authorization mechanics explicit enough to be useful in the layering debate/refinement process?
